### PR TITLE
fix BLOCKSTORE_DEBUG, error: ‘dirty_it’ was not declared in this scope

### DIFF
--- a/src/blockstore_write.cpp
+++ b/src/blockstore_write.cpp
@@ -478,15 +478,15 @@ resume_2:
     }
 resume_4:
     // Switch object state
-#ifdef BLOCKSTORE_DEBUG
-    printf("Ack write %lx:%lx v%lu = state 0x%x\n", op->oid.inode, op->oid.stripe, op->version, dirty_it->second.state);
-#endif
     {
         auto dirty_it = dirty_db.find((obj_ver_id){
             .oid = op->oid,
             .version = op->version,
         });
         assert(dirty_it != dirty_db.end());
+#ifdef BLOCKSTORE_DEBUG
+        printf("Ack write %lx:%lx v%lu = state 0x%x\n", op->oid.inode, op->oid.stripe, op->version, dirty_it->second.state);
+#endif
         bool is_big = (dirty_it->second.state & BS_ST_TYPE_MASK) == BS_ST_BIG_WRITE;
         bool imm = is_big ? (immediate_commit == IMMEDIATE_ALL) : (immediate_commit != IMMEDIATE_NONE);
         if (imm)


### PR DESCRIPTION
Signed-off-by: JiangYu <lnsyyj@hotmail.com>

When BLOCKSTORE_DEBUG is turned on, dirty_it is not defined

```
[ 69%] Building CXX object src/CMakeFiles/vitastor_blk.dir/blockstore_rollback.cpp.o
/root/github/vitastor/src/blockstore_write.cpp: In member function ‘int blockstore_impl_t::continue_write(blockstore_op_t*)’:
/root/github/vitastor/src/blockstore_write.cpp:482:97: error: ‘dirty_it’ was not declared in this scope; did you mean ‘dirty_db’?
  482 |     printf("Ack write %lx:%lx v%lu = state 0x%x\n", op->oid.inode, op->oid.stripe, op->version, dirty_it->second.state);
      |                                                                                                 ^~~~~~~~
      |                                                                                                 dirty_db
make[2]: *** [src/CMakeFiles/vitastor_blk.dir/build.make:173: src/CMakeFiles/vitastor_blk.dir/blockstore_write.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
[ 70%] Linking CXX executable stub_uring_osd
```