### PR TITLE
journal check_available error

### DIFF
--- a/src/blockstore_journal.cpp
+++ b/src/blockstore_journal.cpp
@@ -96,7 +96,8 @@ int blockstore_journal_check_t::check_available(blockstore_op_t *op, int entries
         next_pos = next_pos + data_after;
         if (next_pos > bs->journal.len)
         {
-            next_pos = bs->journal.block_size + data_after;
+            if (right_dir)
+                next_pos = bs->journal.block_size + data_after;
             right_dir = false;
         }
     }


### PR DESCRIPTION
if journal used_start close to journal len and then with small write will cause journal check_available error (no_same_sector_overwrites == true). for example: journal.len : 0x1000000, used_start : 0xffa000, next_free: 0xff8000.  for write 4k data to journal, because (next_free + journal.entry + data + JOURNAL_STABILIZE_RESERVATION ) is over journal len , then next_pos = next_pos + data_after.  it not satisfy next_pos >= bs->journal.used_start-bs->journal.block_size, so data allow to write to journal, it is incorrect. 