### PR TITLE
#1 fix deps

### DIFF
--- a/src/cli_flatten.cpp
+++ b/src/cli_flatten.cpp
@@ -3,6 +3,7 @@
 
 #include "cli.h"
 #include "cluster_client.h"
+#include <sys/stat.h>
 
 // Flatten a layer: merge all parents into a layer and break the connection completely
 struct snap_flattener_t

--- a/src/cli_simple_offsets.cpp
+++ b/src/cli_simple_offsets.cpp
@@ -8,6 +8,7 @@
 #include "cli.h"
 #include "cluster_client.h"
 #include "base64.h"
+#include <sys/stat.h>
 
 // Calculate offsets for a block device and print OSD command line parameters
 std::function<bool(void)> cli_tool_t::simple_offsets(json11::Json cfg)


### PR DESCRIPTION
this change fixes errors:
```
[ 87%] Building CXX object src/CMakeFiles/vitastor-cli.dir/cli_flatten.cpp.o
lcc: "/root/workdir/vitastor/src/cli_simple_offsets.cpp", line 37: error #144:
          a value of type "const char *" cannot be used to initialize an entity
          of type "__dev_t"
          if (stat(device.c_str(), &st) < 0)
                   ^

lcc: "/root/workdir/vitastor/src/cli_simple_offsets.cpp", line 37: error #144:
          a value of type "stat *" cannot be used to initialize an entity of
          type "__ino_t"
          if (stat(device.c_str(), &st) < 0)
                                   ^

lcc: "/root/workdir/vitastor/src/cli_simple_offsets.cpp", line 42: error #20:
          identifier "S_ISBLK" is undefined
          if (S_ISBLK(st.st_mode))
              ^

lcc: "/root/workdir/vitastor/src/cli_simple_offsets.cpp", line 60: error #20:
          identifier "S_ISREG" is undefined
          else if (S_ISREG(st.st_mode))
                   ^

```