### PR TITLE
fix: avoid multiple inflight overwrites to meta blocks

### DIFF
--- a/src/blockstore/blockstore_flush.h
+++ b/src/blockstore/blockstore_flush.h
@@ -76,6 +76,7 @@ class journal_flusher_co
     uint8_t *new_clean_bitmap;
 
     uint64_t new_trim_pos;
+    std::unordered_set<uint64_t>::iterator inflight_meta_sector;
 
     friend class journal_flusher_t;
     void scan_dirty();
@@ -120,6 +121,7 @@ class journal_flusher_t
     std::map<uint64_t, meta_sector_t> meta_sectors;
     std::deque<object_id> flush_queue;
     std::map<object_id, uint64_t> flush_versions; // FIXME: consider unordered_map?
+    std::unordered_set<uint64_t> inflight_meta_sectors;
 
     bool try_find_older(std::map<obj_ver_id, dirty_entry>::iterator & dirty_end, obj_ver_id & cur);
     bool try_find_other(std::map<obj_ver_id, dirty_entry>::iterator & dirty_end, obj_ver_id & cur);

--- a/src/blockstore/blockstore_impl.h
+++ b/src/blockstore/blockstore_impl.h
@@ -19,6 +19,7 @@
 #include <deque>
 #include <new>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "cpp-btree/btree_map.h"
 


### PR DESCRIPTION
As mentioned in #79 , we discovered that there're multiple coroutines writing to a same metadata block and referencing the same memory region, causing the written data to be inconsistent on certain hardware. Once we serialized the metadata block updates like this, the problem is fixed and only a small portion of performance is sacrificed.

I accept Vitastor CLA agreement: https://git.yourcmc.ru/vitalif/vitastor/src/branch/master/CLA-en.md