### PR TITLE
fix base64 decode on arm64

### DIFF
--- a/src/util/str_util.cpp
+++ b/src/util/str_util.cpp
@@ -30,7 +30,7 @@ std::string base64_encode(const std::string &in)
     return out;
 }
 
-static char T[256] = { 0 };
+static signed char T[256] = { 0 };
 
 std::string base64_decode(const std::string &in)
 {


### PR DESCRIPTION
### Description
We tested Vitastor on arm64, and it performed well overall, except this base64 decoding issue.

### CLA
- [x] I accept Vitastor CLA agreement: https://git.yourcmc.ru/vitalif/vitastor/src/branch/master/CLA-en.md