### PR TITLE
Fix vitastor-cli ls shows raw usage when pool is specified

### DIFF
--- a/src/cmd/cli_ls.cpp
+++ b/src/cmd/cli_ls.cpp
@@ -97,11 +97,11 @@ struct image_lister_t
                     { "request_range", json11::Json::object {
                         { "key", base64_encode(
                             parent->cli->st_cli.etcd_prefix+"/pool/stats"+
-                            (list_pool_id ? "/"+std::to_string(list_pool_id) : "")+"/"
+                            (list_pool_id ? "/"+std::to_string(list_pool_id) : "/")
                         ) },
                         { "range_end", base64_encode(
                             parent->cli->st_cli.etcd_prefix+"/pool/stats"+
-                            (list_pool_id ? "/"+std::to_string(list_pool_id) : "")+"0"
+                            (list_pool_id ? "/"+std::to_string(list_pool_id+1) : "0")
                         ) },
                     } },
                 },


### PR DESCRIPTION
Hi,

Here's another trivial bug I found in vitastor-cli tool. When `--pool` is specified, `vitastor-cli ls -l` will fail to retrieve the the pool stats (the `/vitastor/pool/stats/<pool_id>` key should have no ending `/` in the `request_range` request) , it will therefore show raw used size of images.

By submitting this pull request, I accept [Vitastor CLA](https://git.yourcmc.ru/vitalif/vitastor/src/branch/master/CLA-en.md)