### PR TITLE
fix: journal sector's written flag not set when it is submitted

### DIFF
--- a/src/blockstore/blockstore_impl.cpp
+++ b/src/blockstore/blockstore_impl.cpp
@@ -228,9 +228,9 @@ void blockstore_impl_t::loop()
         for (auto s: journal.submitting_sectors)
         {
             // Mark journal sector writes as submitted
-            journal.sector_info[s].submit_id = 0;
             if (journal.sector_info[s].submit_id)
                 journal.sector_info[s].written = true;
+            journal.sector_info[s].submit_id = 0;
         }
         journal.submitting_sectors.clear();
         if ((initial_ring_space - ringloop->space_left()) > 0)


### PR DESCRIPTION
Hi, @vitalif 

It appears the journal sector's written flag will never be set to true after applying the "[optimze WA](https://github.com/vitalif/vitastor/commit/d87e7d1a378b7551af5c2f72b6d88f4405503fb4)" optimization.

By submitting this pull request, I accept [Vitastor CLA](https://git.yourcmc.ru/vitalif/vitastor/src/branch/master/CLA-en.md)
