### PR TITLE
fix pool stats with no_inode_stats

### DIFF
--- a/src/blockstore/blockstore_heap.cpp
+++ b/src/blockstore/blockstore_heap.cpp
@@ -2131,7 +2131,7 @@ void blockstore_heap_t::use_data(inode_t inode, uint64_t location)
 {
     auto sh_it = pool_shard_settings.find(INODE_POOL(inode));
     if (sh_it != pool_shard_settings.end() && sh_it->second.no_inode_stats)
-        inode = (INODE_POOL(inode) << POOL_ID_BITS);
+        inode = INODE_WITH_POOL(INODE_POOL(inode), 0);
     assert(!data_alloc->get(location / dsk->data_block_size));
     data_alloc->set(location / dsk->data_block_size, true);
     inode_space_stats[inode] += dsk->data_block_size;
@@ -2142,7 +2142,7 @@ void blockstore_heap_t::free_data(inode_t inode, uint64_t location)
 {
     auto sh_it = pool_shard_settings.find(INODE_POOL(inode));
     if (sh_it != pool_shard_settings.end() && sh_it->second.no_inode_stats)
-        inode = (INODE_POOL(inode) << POOL_ID_BITS);
+        inode = INODE_WITH_POOL(INODE_POOL(inode), 0);
     assert(data_alloc->get(location / dsk->data_block_size));
     data_alloc->set(location / dsk->data_block_size, false);
     auto sp_it = inode_space_stats.find(inode);


### PR DESCRIPTION
Pool stats are incorrect when no_inode_stats is enabled because use_data/free_data do not aggregate space changes to the pool-level inode.