### PR TITLE
Fix uninitialized HTTP context causing a segfault

### DIFF
--- a/src/cmd/cli_serve.cpp
+++ b/src/cmd/cli_serve.cpp
@@ -365,10 +365,17 @@ struct cli_serve_t
         conn->p->is_command_line = false;
         // Parse request
         auto req_line = explode(" ", msg->status_line, true);
+        if (req_line.empty())
+        {
+            conn->result = { .err = EINVAL, .text = "Invalid request line" };
+            http_reply(conn->co, cli_http_response(conn));
+            delete conn->p;
+            conn->p = NULL;
+            return;
+        }
         if (req_line.size() < 2)
         {
-            if (req_line[0] == "")
-                req_line[0] = "-";
+            // Checked if req_line is empty, so size must be 1 now
             req_line.push_back("-");
         }
         conn->request_time = ts;

--- a/src/cmd/cli_serve.cpp
+++ b/src/cmd/cli_serve.cpp
@@ -131,24 +131,24 @@ struct cli_serve_t
                     state = 100;
                     return;
                 }
-                std::string error;
-                http_ctx = http_context_init(parent->epmgr->tfd, api_cert, api_pkey, client_ca, client_ca != "", error);
-                if (error != "")
+            }
+            std::string error;
+            http_ctx = http_context_init(parent->epmgr->tfd, api_cert, api_pkey, client_ca, client_ca != "", error);
+            if (error != "")
+            {
+                result = (cli_result_t){ .err = EINVAL, .text = error };
+                state = 100;
+                return;
+            }
+            if (client_ca != "" && admin_ca != "")
+            {
+                bool ok = http_context_add_ca(http_ctx, admin_ca);
+                if (!ok)
                 {
-                    result = (cli_result_t){ .err = EINVAL, .text = error };
+                    http_context_destroy(http_ctx);
+                    result = (cli_result_t){ .err = EINVAL, .text = "Failed to load admin_ca" };
                     state = 100;
                     return;
-                }
-                if (client_ca != "" && admin_ca != "")
-                {
-                    bool ok = http_context_add_ca(http_ctx, admin_ca);
-                    if (!ok)
-                    {
-                        http_context_destroy(http_ctx);
-                        result = (cli_result_t){ .err = EINVAL, .text = "Failed to load admin_ca" };
-                        state = 100;
-                        return;
-                    }
                 }
             }
             if (use_perms && client_ca == "")

--- a/src/cmd/cli_serve.cpp
+++ b/src/cmd/cli_serve.cpp
@@ -458,7 +458,7 @@ struct cli_serve_t
                 else
                 {
                     // Parse URI
-                    cfg = parse_uri_params(uri[1]);
+                    cfg = parse_uri_params(uri.size() > 1 ? uri[1] : "");
                 }
                 if (error != "")
                 {

--- a/src/cmd/cli_serve.cpp
+++ b/src/cmd/cli_serve.cpp
@@ -402,82 +402,89 @@ struct cli_serve_t
         else
         {
             auto uri = explode("?", conn->request_path, true);
-            uri[0] = trim(uri[0], "/");
-            auto cmd_it = cmd_paths.find(uri[0]);
-            if (uri[0] == "")
+            if (uri.empty())
             {
-                std::string text = "Supported APIs:\n\n- GET /openapi\n";
-                for (auto & pp: cmd_paths)
-                {
-                    text += (pp.second.allow_get ? "- GET" : "- POST") + (" /" + pp.first) + "\n";
-                }
-                conn->result = { .text = text };
-            }
-            else if (uri[0] == "openapi")
-            {
-                conn->response_type = "application/json";
-                conn->result = { .text = openapi_description };
-                if (use_perms)
-                {
-                    // Filter available paths by privileges
-                    if (!conn->p->is_admin)
-                    {
-                        std::string error;
-                        auto openapi = json11::Json::parse(openapi_description, error).object_items();
-                        json11::Json::object paths;
-                        for (auto & kv: openapi["paths"].object_items())
-                        {
-                            auto cmd_it = cmd_paths.find(kv.first.substr(1));
-                            if (cmd_it != cmd_paths.end() && cmd_it->second.allow_client)
-                            {
-                                paths[kv.first] = kv.second;
-                            }
-                        }
-                        openapi["paths"] = paths;
-                        conn->response_type = "application/json";
-                        conn->result = { .text = json11::Json(openapi).dump() };
-                    }
-                    else if (!conn->p->user)
-                    {
-                        conn->response_type = "";
-                        conn->result = { .err = EACCES, .text = "Access denied" };
-                    }
-                }
-            }
-            else if (cmd_it == cmd_paths.end())
-            {
-                conn->result = { .err = EOPNOTSUPP, .text = "unknown command: "+uri[0] };
-            }
-            else if (conn->request_method == "GET" && !cmd_it->second.allow_get)
-            {
-                conn->result = { .err = ENOSYS, .text = "method /"+uri[0]+" only allows POST requests" };
-            }
-            else if (use_perms && !conn->p->is_admin && !cmd_it->second.allow_client)
-            {
-                conn->result = { .err = EACCES, .text = "Access denied" };
+                conn->result = { .err = EINVAL, .text = "Invalid request path" };
             }
             else
             {
-                std::string error;
-                json11::Json::object cfg;
-                if (conn->request_method == "POST")
+                uri[0] = trim(uri[0], "/");
+                auto cmd_it = cmd_paths.find(uri[0]);
+                if (uri[0] == "")
                 {
-                    cfg = json11::Json::parse(conn->request_body, error).object_items();
+                    std::string text = "Supported APIs:\n\n- GET /openapi\n";
+                    for (auto & pp: cmd_paths)
+                    {
+                        text += (pp.second.allow_get ? "- GET" : "- POST") + (" /" + pp.first) + "\n";
+                    }
+                    conn->result = { .text = text };
+                }
+                else if (uri[0] == "openapi")
+                {
+                    conn->response_type = "application/json";
+                    conn->result = { .text = openapi_description };
+                    if (use_perms)
+                    {
+                        // Filter available paths by privileges
+                        if (!conn->p->is_admin)
+                        {
+                            std::string error;
+                            auto openapi = json11::Json::parse(openapi_description, error).object_items();
+                            json11::Json::object paths;
+                            for (auto & kv: openapi["paths"].object_items())
+                            {
+                                auto cmd_it = cmd_paths.find(kv.first.substr(1));
+                                if (cmd_it != cmd_paths.end() && cmd_it->second.allow_client)
+                                {
+                                    paths[kv.first] = kv.second;
+                                }
+                            }
+                            openapi["paths"] = paths;
+                            conn->response_type = "application/json";
+                            conn->result = { .text = json11::Json(openapi).dump() };
+                        }
+                        else if (!conn->p->user)
+                        {
+                            conn->response_type = "";
+                            conn->result = { .err = EACCES, .text = "Access denied" };
+                        }
+                    }
+                }
+                else if (cmd_it == cmd_paths.end())
+                {
+                    conn->result = { .err = EOPNOTSUPP, .text = "unknown command: "+uri[0] };
+                }
+                else if (conn->request_method == "GET" && !cmd_it->second.allow_get)
+                {
+                    conn->result = { .err = ENOSYS, .text = "method /"+uri[0]+" only allows POST requests" };
+                }
+                else if (use_perms && !conn->p->is_admin && !cmd_it->second.allow_client)
+                {
+                    conn->result = { .err = EACCES, .text = "Access denied" };
                 }
                 else
                 {
-                    // Parse URI
-                    cfg = parse_uri_params(uri.size() > 1 ? uri[1] : "");
-                }
-                if (error != "")
-                {
-                    conn->result = { .err = EINVAL, .text = "Invalid JSON in body: "+error };
-                }
-                else
-                {
-                    cfg["command"] = json11::Json::array{cmd_it->second.cmd};
-                    conn->p->parse_api_opts(cfg);
-                    conn->action_cb = conn->p->start(cfg, conn->result);
+                    std::string error;
+                    json11::Json::object cfg;
+                    if (conn->request_method == "POST")
+                    {
+                        cfg = json11::Json::parse(conn->request_body, error).object_items();
+                    }
+                    else
+                    {
+                        // Parse URI
+                        cfg = parse_uri_params(uri.size() > 1 ? uri[1] : "");
+                    }
+                    if (error != "")
+                    {
+                        conn->result = { .err = EINVAL, .text = "Invalid JSON in body: "+error };
+                    }
+                    else
+                    {
+                        cfg["command"] = json11::Json::array{cmd_it->second.cmd};
+                        conn->p->parse_api_opts(cfg);
+                        conn->action_cb = conn->p->start(cfg, conn->result);
+                    }
                 }
             }
         }

--- a/src/cmd/cli_serve.cpp
+++ b/src/cmd/cli_serve.cpp
@@ -388,7 +388,9 @@ struct cli_serve_t
             conn->p->user = parent->cli->st_cli->get_user(msg->tls_cn);
             conn->p->is_admin = msg->tls_ca_idx >= 1;
         }
-        auto ctype = msg->headers["content-type"];
+        // Don't insert a new value
+        auto ctype_it = msg->headers.find("content-type");
+        std::string ctype = (ctype_it != msg->headers.end()) ? ctype_it->second : "";
         if (conn->request_method != "GET" && conn->request_method != "POST")
         {
             conn->result = { .err = ENOSYS, .text = "Unsupported request method "+conn->request_method };


### PR DESCRIPTION
I wanted to try out the `vitastor-cli serve` API, however I hit a crash.

Some quick printf debugging revealed that ctx=NULL in http_init:

```
http_co_t *http_init(http_context_t *ctx)
{
    http_co_t *handler = new http_co_t();
    handler->tfd = ctx->tfd; // <== NULL deref
    handler->state = HTTP_CO_CLOSED;
    handler->ctx = ctx;
    return handler;
}
```

`http_context_init(...)` is never called when used without SSL options. This PR changes the behaviour to what I assume was the intended logic.
